### PR TITLE
Added bz2 extension

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get install -y \
     php8.1-intl \
     php8.1-imap \
     php8.1-phpdbg \
+    php8.1-bz2 \
     php8.1-redis
 
 # composer


### PR DESCRIPTION
Some composer packages require the bz2 extension when running the `composer install` step of the test suite. Was debating on forking but others may need the extension too.

```
requires ext-bz2 * -> it is missing from your system. Install or enable PHP's bz2 extension.
```