### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/php-7.1-publish.yml
+++ b/.github/workflows/php-7.1-publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/php-7.2-publish.yml
+++ b/.github/workflows/php-7.2-publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/php-7.3-publish.yml
+++ b/.github/workflows/php-7.3-publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/php-7.4-couch-mongo-publish.yml
+++ b/.github/workflows/php-7.4-couch-mongo-publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/php-7.4-publish.yml
+++ b/.github/workflows/php-7.4-publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/php-8.0-couch-mongo-publish.yml
+++ b/.github/workflows/php-8.0-couch-mongo-publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/php-8.0-publish.yml
+++ b/.github/workflows/php-8.0-publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/php-8.1-couch-mongo.yml
+++ b/.github/workflows/php-8.1-couch-mongo.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/php-8.1-publish.yml
+++ b/.github/workflows/php-8.1-publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/php-8.2-publish.yml
+++ b/.github/workflows/php-8.2-publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kirschbaumdevelopment/laravel-test-runner
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore