### PR TITLE
PHP 8.3 upgrade

### DIFF
--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:20.04
 LABEL maintainer="Luis Dalmolin <luis@kirschbaumdevelopment.com>"
 ARG DEBIAN_FRONTEND=noninteractive
 
+ENV PHP_VERSION="8.3"
 ENV GOSS_VERSION="0.3.6"
 
 RUN apt-get update && apt-get install -y software-properties-common curl
@@ -10,25 +11,25 @@ RUN add-apt-repository ppa:git-core/ppa -y
 RUN apt-get update -y
 RUN apt-get install -y \
     unzip \
-    php8.3-cli \
-    php8.3-gd \
-    php8.3-ldap \
-    php8.3-mbstring \
-    php8.3-mysql \
-    php8.3-pgsql \
-    php8.3-sqlite3 \
-    php8.3-xml \
-    php8.3-xsl \
-    php8.3-zip \
-    php8.3-curl \
-    php8.3-soap \
-    php8.3-gmp \
-    php8.3-bcmath \
-    php8.3-intl \
-    php8.3-imap \
-    php8.3-phpdbg \
-    php8.3-bz2 \
-    php8.3-redis
+    php${PHP_VERSION}-cli \
+    php${PHP_VERSION}-gd \
+    php${PHP_VERSION}-ldap \
+    php${PHP_VERSION}-mbstring \
+    php${PHP_VERSION}-mysql \
+    php${PHP_VERSION}-pgsql \
+    php${PHP_VERSION}-sqlite3 \
+    php${PHP_VERSION}-xml \
+    php${PHP_VERSION}-xsl \
+    php${PHP_VERSION}-zip \
+    php${PHP_VERSION}-curl \
+    php${PHP_VERSION}-soap \
+    php${PHP_VERSION}-gmp \
+    php${PHP_VERSION}-bcmath \
+    php${PHP_VERSION}-intl \
+    php${PHP_VERSION}-imap \
+    php${PHP_VERSION}-phpdbg \
+    php${PHP_VERSION}-bz2 \
+    php${PHP_VERSION}-redis
 
 # composer
 ENV COMPOSER_HOME=/composer

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -4,8 +4,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ENV PHP_VERSION="8.3"
 ENV GOSS_VERSION="0.4.4"
+ENV NODE_MAJOR="20"
 
-RUN apt-get update && apt-get install -y software-properties-common curl
+RUN apt-get update && apt-get install -y software-properties-common curl ca-certificates gnupg
 RUN add-apt-repository ppa:ondrej/php -y
 RUN add-apt-repository ppa:git-core/ppa -y
 RUN apt-get update -y
@@ -43,9 +44,14 @@ RUN apt-get install -y mysql-client
 # git
 RUN apt-get install -y git
 
-# node and yarn
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs
+# node
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install nodejs -y
+
+
+# yarn
 RUN npm install -g yarn
 
 # goss

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL maintainer="Luis Dalmolin <luis@kirschbaumdevelopment.com>"
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Luis Dalmolin <luis@kirschbaumdevelopment.com>"
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV PHP_VERSION="8.3"
-ENV GOSS_VERSION="0.3.6"
+ENV GOSS_VERSION="0.4.4"
 
 RUN apt-get update && apt-get install -y software-properties-common curl
 RUN add-apt-repository ppa:ondrej/php -y

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:20.04
+LABEL maintainer="Luis Dalmolin <luis@kirschbaumdevelopment.com>"
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV GOSS_VERSION="0.3.6"
+
+RUN apt-get update && apt-get install -y software-properties-common curl
+RUN add-apt-repository ppa:ondrej/php -y
+RUN add-apt-repository ppa:git-core/ppa -y
+RUN apt-get update -y
+RUN apt-get install -y \
+    unzip \
+    php8.3-cli \
+    php8.3-gd \
+    php8.3-ldap \
+    php8.3-mbstring \
+    php8.3-mysql \
+    php8.3-pgsql \
+    php8.3-sqlite3 \
+    php8.3-xml \
+    php8.3-xsl \
+    php8.3-zip \
+    php8.3-curl \
+    php8.3-soap \
+    php8.3-gmp \
+    php8.3-bcmath \
+    php8.3-intl \
+    php8.3-imap \
+    php8.3-phpdbg \
+    php8.3-bz2 \
+    php8.3-redis
+
+# composer
+ENV COMPOSER_HOME=/composer
+ENV PATH=./vendor/bin:/composer/vendor/bin:/root/.yarn/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# mysql client
+RUN apt-get install -y mysql-client
+
+# git
+RUN apt-get install -y git
+
+# node and yarn
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y nodejs
+RUN npm install -g yarn
+
+# goss
+RUN curl -fsSL https://goss.rocks/install | GOSS_VER=v${GOSS_VERSION} sh

--- a/8.3/goss.yaml
+++ b/8.3/goss.yaml
@@ -1,0 +1,39 @@
+command:
+  node --version:
+    exit-status: 0
+    stdout:
+      - "v16"
+  yarn --version:
+    exit-status: 0
+  npm --version:
+    exit-status: 0
+    stdout:
+      - "8"
+  git --version:
+    exit-status: 0
+  composer --version:
+    exit-status: 0
+  php --version:
+    exit-status: 0
+    stdout:
+      - 8.3
+  php -m:
+    exit-status: 0
+    stdout:
+      - bcmath
+      - calendar
+      - exif
+      - gd
+      - iconv
+      - imap
+      - intl
+      - ldap
+      - mbstring
+      - mysqli
+      - pcntl
+      - pdo_mysql
+      - pdo_pgsql
+      - pgsql
+      - soap
+      - xml
+      - zip

--- a/8.3/goss.yaml
+++ b/8.3/goss.yaml
@@ -2,13 +2,13 @@ command:
   node --version:
     exit-status: 0
     stdout:
-      - "v16"
+      - "v20"
   yarn --version:
     exit-status: 0
   npm --version:
     exit-status: 0
     stdout:
-      - "8"
+      - "10"
   git --version:
     exit-status: 0
   composer --version:

--- a/8.3/readme.md
+++ b/8.3/readme.md
@@ -1,0 +1,31 @@
+# Laravel Test Runner - PHP 8.3
+
+Docker Container with PHP 8.3 and extensions to be compatible with most Laravel applications. Also installed on this container we have Composer and NodeJS/NPM/Yarn.
+
+## Building and pushing the image
+
+**Build**:
+
+```
+docker build --pull -t kirschbaumdevelopment/laravel-test-runner .
+```
+
+**Tag**:
+
+```
+docker tag kirschbaumdevelopment/laravel-test-runner:latest kirschbaumdevelopment/laravel-test-runner:8.3
+```
+
+**Push**:
+
+```
+docker push kirschbaumdevelopment/laravel-test-runner:8.3
+```
+
+## Credits
+
+- [Pushpak Chhajed](https://github.com/pushpak1300)
+
+## Sponsorship
+
+Development of this package is sponsored by Kirschbaum Development Group, a developer driven company focused on problem solving, team building, and community. Learn more [about us](https://kirschbaumdevelopment.com) or [join us](https://careers.kirschbaumdevelopment.com)!


### PR DESCRIPTION
I have adapted the Dockerfile with PHP 8.3 with the following changes:

- Ubuntu upgrade to latest LTS (22)
- Node and NPM upgrade to latest LTS (Node 20, NPM 10)
    - The used install script was deprecated; I followed the official installation instructions
- Goss upgrade to latest (0.4.4)

For testing, I pushed it to [my own Dockerhub repo](https://hub.docker.com/repository/docker/niekb62/laravel-test-runner/general).

This fixes #40

Regards,
Niek

