### PR TITLE
Add xdebug to PHP extensions to do coverage testing

### DIFF
--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get install -y \
     php8.2-imap \
     php8.2-phpdbg \
     php8.2-bz2 \
+    php8.2-xdebug \
     php8.2-redis
 
 # composer

--- a/8.2/goss.yaml
+++ b/8.2/goss.yaml
@@ -35,5 +35,6 @@ command:
       - pdo_pgsql
       - pgsql
       - soap
+      - xdebug
       - xml
       - zip

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get install -y \
     php${PHP_VERSION}-imap \
     php${PHP_VERSION}-phpdbg \
     php${PHP_VERSION}-bz2 \
+    php${PHP_VERSION}-xdebug \
     php${PHP_VERSION}-redis
 
 # composer

--- a/8.3/goss.yaml
+++ b/8.3/goss.yaml
@@ -35,5 +35,6 @@ command:
       - pdo_pgsql
       - pgsql
       - soap
+      - xdebug
       - xml
       - zip

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get install -y \
     php${PHP_VERSION}-imap \
     php${PHP_VERSION}-phpdbg \
     php${PHP_VERSION}-bz2 \
+    php${PHP_VERSION}-xdebug \
     php${PHP_VERSION}-redis
 
 # composer

--- a/8.4/goss.yaml
+++ b/8.4/goss.yaml
@@ -35,5 +35,6 @@ command:
       - pdo_pgsql
       - pgsql
       - soap
+      - xdebug
       - xml
       - zip


### PR DESCRIPTION
Instead of generate a new full docker to just add xdebug (which is very common), I prefer to merge everything in the same repo.

If this PR is rejected, I'll just create a new repo extending the current dockers and installing the deps.

## Why PR instead of just installing the whole time?

Performance reasons, again, coverage is very common, also debugging.