### PR TITLE
chore: Add support Couchbase and MongoDB for PHP 8.3,8.4

### DIFF
--- a/.github/workflows/php-8.3-couch-mongo-publish.yml
+++ b/.github/workflows/php-8.3-couch-mongo-publish.yml
@@ -1,0 +1,30 @@
+name: php-8.3-couch-mongo-publish
+on:
+  release:
+    types: [published]
+    
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: ./.github/actions/docker-publish
+      name: Build and Publish (8.3)
+      with:
+        version: 8.3
+        docker-username: ${{ secrets.DOCKER_USERNAME }}
+        docker-password: ${{ secrets.DOCKER_TOKEN }}
+  
+  validate:
+    runs-on: ubuntu-latest
+    needs: publish
+    container:
+      image: kirschbaumdevelopment/laravel-test-runner:8.3-couch-mongo
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -fsSL https://goss.rocks/install | GOSS_VER=v${GOSS_VERSION} sh
+          goss --gossfile 8.3-couch-mongo/goss.yaml validate

--- a/.github/workflows/php-8.4-couch-mongo-publish.yml
+++ b/.github/workflows/php-8.4-couch-mongo-publish.yml
@@ -1,0 +1,30 @@
+name: php-8.4-couch-mongo-publish
+on:
+  release:
+    types: [published]
+    
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: ./.github/actions/docker-publish
+      name: Build and Publish (8.4)
+      with:
+        version: 8.4
+        docker-username: ${{ secrets.DOCKER_USERNAME }}
+        docker-password: ${{ secrets.DOCKER_TOKEN }}
+  
+  validate:
+    runs-on: ubuntu-latest
+    needs: publish
+    container:
+      image: kirschbaumdevelopment/laravel-test-runner:8.4-couch-mongo
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -fsSL https://goss.rocks/install | GOSS_VER=v${GOSS_VERSION} sh
+          goss --gossfile 8.4-couch-mongo/goss.yaml validate

--- a/8.3-couch-mongo/Dockerfile
+++ b/8.3-couch-mongo/Dockerfile
@@ -1,0 +1,28 @@
+FROM kirschbaumdevelopment/laravel-test-runner:8.3
+
+ENV PHP_VERSION="8.4"
+ENV MONGODB_VERSION="2.0.0"
+ENV COUCHBASE_VERSION="3.2.2"
+
+# Install system dependencies for couchbase
+RUN apt-get install -y wget
+RUN wget -O - https://packages.couchbase.com/clients/c/repos/deb/couchbase.key | apt-key add -
+RUN echo "deb https://packages.couchbase.com/clients/c/repos/deb/ubuntu1804 bionic bionic/main" | tee /etc/apt/sources.list.d/couchbase.list
+RUN apt-get update 
+RUN apt-get install -y libcouchbase3 libcouchbase-dev
+
+## Install PECL
+RUN apt-get install -y php-pear php${PHP_VERSION}-dev php${PHP_VERSION}-xml
+### Making sure we're using the correct php version
+RUN rm /etc/alternatives/php
+RUN ln -s /usr/bin/php${PHP_VERSION} /etc/alternatives/php
+
+
+## MongoDB
+RUN pecl install mongodb-${MONGODB_VERSION}
+RUN echo "extension=mongodb.so" | tee -a /etc/php/${PHP_VERSION}/cli/conf.d/20-mongodb.ini
+
+
+## Couchbase
+RUN pecl install couchbase-${COUCHBASE_VERSION}
+RUN echo "extension=couchbase.so" | tee -a /etc/php/${PHP_VERSION}/cli/conf.d/30-couchbase.ini

--- a/8.3-couch-mongo/goss.yaml
+++ b/8.3-couch-mongo/goss.yaml
@@ -1,0 +1,41 @@
+command:
+  node --version:
+    exit-status: 0
+    stdout:
+      - "v20"
+  yarn --version:
+    exit-status: 0
+  npm --version:
+    exit-status: 0
+    stdout:
+      - "10"
+  git --version:
+    exit-status: 0
+  composer --version:
+    exit-status: 0
+  php --version:
+    exit-status: 0
+    stdout:
+      - 8.3
+  php -m:
+    exit-status: 0
+    stdout:
+      - bcmath
+      - calendar
+      - exif
+      - gd
+      - iconv
+      - imap
+      - intl
+      - ldap
+      - mbstring
+      - mysqli
+      - pcntl
+      - pdo_mysql
+      - pdo_pgsql
+      - pgsql
+      - soap
+      - xml
+      - zip
+      - mongodb
+      - couchbase

--- a/8.3-couch-mongo/readme.md
+++ b/8.3-couch-mongo/readme.md
@@ -1,0 +1,33 @@
+# Canvas Test Runner
+
+Docker Container with PHP and extensions to be compatible with most Laravel applications. Also installed on this container we have Composer and NodeJS/NPM/Yarn.
+
+## Building and pushing the image
+
+**Build**:
+
+```
+docker build --pull -t kirschbaumdevelopment/laravel-test-runner .
+```
+
+**Tag**:
+
+```
+docker tag kirschbaumdevelopment/laravel-test-runner:latest kirschbaumdevelopment/laravel-test-runner:8.1-couch-mongo
+```
+
+**Login**
+```
+docker login --username=yourhubusername --email=youremail@provider.com
+```
+
+
+**Push**:
+
+```
+docker push kirschbaumdevelopment/laravel-test-runner:8.1-couch-mongo
+```
+
+## Credits
+
+- [Luis Dalmolin](https://github.com/luisdalmolin)

--- a/8.4-couch-mongo/Dockerfile
+++ b/8.4-couch-mongo/Dockerfile
@@ -1,0 +1,28 @@
+FROM kirschbaumdevelopment/laravel-test-runner:8.4
+
+ENV PHP_VERSION="8.4"
+ENV MONGODB_VERSION="2.0.0"
+ENV COUCHBASE_VERSION="3.2.2"
+
+# Install system dependencies for couchbase
+RUN apt-get install -y wget
+RUN wget -O - https://packages.couchbase.com/clients/c/repos/deb/couchbase.key | apt-key add -
+RUN echo "deb https://packages.couchbase.com/clients/c/repos/deb/ubuntu1804 bionic bionic/main" | tee /etc/apt/sources.list.d/couchbase.list
+RUN apt-get update 
+RUN apt-get install -y libcouchbase3 libcouchbase-dev
+
+## Install PECL
+RUN apt-get install -y php-pear php${PHP_VERSION}-dev php${PHP_VERSION}-xml
+### Making sure we're using the correct php version
+RUN rm /etc/alternatives/php
+RUN ln -s /usr/bin/php${PHP_VERSION} /etc/alternatives/php
+
+
+## MongoDB
+RUN pecl install mongodb-${MONGODB_VERSION}
+RUN echo "extension=mongodb.so" | tee -a /etc/php/${PHP_VERSION}/cli/conf.d/20-mongodb.ini
+
+
+## Couchbase
+RUN pecl install couchbase-${COUCHBASE_VERSION}
+RUN echo "extension=couchbase.so" | tee -a /etc/php/${PHP_VERSION}/cli/conf.d/30-couchbase.ini

--- a/8.4-couch-mongo/goss.yaml
+++ b/8.4-couch-mongo/goss.yaml
@@ -1,0 +1,41 @@
+command:
+  node --version:
+    exit-status: 0
+    stdout:
+      - "v20"
+  yarn --version:
+    exit-status: 0
+  npm --version:
+    exit-status: 0
+    stdout:
+      - "10"
+  git --version:
+    exit-status: 0
+  composer --version:
+    exit-status: 0
+  php --version:
+    exit-status: 0
+    stdout:
+      - 8.3
+  php -m:
+    exit-status: 0
+    stdout:
+      - bcmath
+      - calendar
+      - exif
+      - gd
+      - iconv
+      - imap
+      - intl
+      - ldap
+      - mbstring
+      - mysqli
+      - pcntl
+      - pdo_mysql
+      - pdo_pgsql
+      - pgsql
+      - soap
+      - xml
+      - zip
+      - mongodb
+      - couchbase

--- a/8.4-couch-mongo/readme.md
+++ b/8.4-couch-mongo/readme.md
@@ -1,0 +1,33 @@
+# Canvas Test Runner
+
+Docker Container with PHP and extensions to be compatible with most Laravel applications. Also installed on this container we have Composer and NodeJS/NPM/Yarn.
+
+## Building and pushing the image
+
+**Build**:
+
+```
+docker build --pull -t kirschbaumdevelopment/laravel-test-runner .
+```
+
+**Tag**:
+
+```
+docker tag kirschbaumdevelopment/laravel-test-runner:latest kirschbaumdevelopment/laravel-test-runner:8.1-couch-mongo
+```
+
+**Login**
+```
+docker login --username=yourhubusername --email=youremail@provider.com
+```
+
+
+**Push**:
+
+```
+docker push kirschbaumdevelopment/laravel-test-runner:8.1-couch-mongo
+```
+
+## Credits
+
+- [Luis Dalmolin](https://github.com/luisdalmolin)


### PR DESCRIPTION
This PR add support for MongoDB and Couchbase with the latest version for PHP 8.3 and 8.4

- MongoDB version 2.0.0
- Couchbase version 3.2.2