### PR TITLE
Update Ubuntu base image to 22.04 for PHP 8.2 container.

### DIFF
--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL maintainer="Luis Dalmolin <luis@kirschbaumdevelopment.com>"
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary
Updates the Ubuntu base image from 20.04 to 22.04 in the PHP 8.2 Dockerfile.

## Changes
- Updated `FROM ubuntu:20.04` to `FROM ubuntu:22.04` in `8.2/Dockerfile`

## Motivation
Ubuntu 20.04 is no longer supported by both GitHub Actions + `shivammathur/setup-php`. 